### PR TITLE
On IE the badges on the buttons are clipped.

### DIFF
--- a/src/sass/index.sass
+++ b/src/sass/index.sass
@@ -80,3 +80,9 @@ $badge-border-radius: 1rem !default
     +badge-size($size-medium)
   &.is-badge-large
     +badge-size($size-large)
+
+ // IE FIX
+// On IE badge was cropped
+.badge
+  &.button:not(.is-clipped)
+    overflow: visible


### PR DESCRIPTION
IE = internet explorer.
I see this problem on IE 11.