### PR TITLE
Make bulma a peer dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -25,8 +25,8 @@
     "url": "https://github.com/Wikiki/bulma-badge/issues"
   },
   "homepage": "https://github.com/Wikiki/bulma-badge#readme",
-  "dependencies": {
-    "bulma": "latest"
+  "peerDependencies": {
+    "bulma": "^0.7.5"
   },
   "devDependencies": {
     "ansi-colors": "^2.0.5",


### PR DESCRIPTION
When using Yarn to install bulma-badge, I get the following warning:

> warning Pattern ["bulma@latest"] is trying to unpack in the same destination "/Users/sbooob/Library/Caches/Yarn/v4/npm-bulma-0.7.5-35066c37f82c088b68f94450be758fc00a967208/node_modules/bulma" as pattern ["bulma@^0.7.5"]. This could result in non-deterministic behavior, skipping.

---

Using the `@latest` dist tag is a bad practice as it may break something by installing a non-backward compatible version when you run `npm update` or `yarn upgrade` in a few months.

bulma-badge is a bulma extension and the concept of [peer dependency](https://docs.npmjs.com/files/package.json#peerdependencies) is particularly [well suited](https://nodejs.org/es/blog/npm/peer-dependencies/) for such a use case.